### PR TITLE
Added callback_url method in order to be able to specify callback url

### DIFF
--- a/lib/omniauth/strategies/dropbox_oauth2.rb
+++ b/lib/omniauth/strategies/dropbox_oauth2.rb
@@ -27,6 +27,14 @@ module OmniAuth
       def raw_info
         @raw_info ||= MultiJson.decode(access_token.get('/1/account/info').body)
       end
+
+      def callback_url
+        if @authorization_code_from_signed_request
+          ''
+        else
+          options[:callback_url] || super
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Dear @bamorin

I'd like to callback from Dropbox site to url specified by my application. So I added `callback_url` method.

usage:

``` ruby
use OmniAuth::Builder do
  provider :dropbox_oauth2, ENV['DROPBOX_KEY'], ENV['DROPBOX_SECRET'],
           :callback_url => 'http://my.service.com/path/to/callback'
end
```

---

Actually, I have created a gem which named [omniauth-dropbox-oauth2](https://github.com/tkengo/omniauth-dropbox-oauth2) in my account's repository at 5 months ago. But at that time I didn't notice that you have created a same gem and published to rubygems. So I'd like to integrate my omniauth-dropbox-oauth2 to your ones because people may confuse if same name gems exist on github.

Callback url can be specified in my gem. Could you merge this pull-request?
