### PR TITLE
Dropbox doesn't seem to like getting the redirect_uri in the token

### DIFF
--- a/lib/omniauth/dropbox_oauth2/version.rb
+++ b/lib/omniauth/dropbox_oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module DropboxOauth2
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/lib/omniauth/strategies/dropbox_oauth2.rb
+++ b/lib/omniauth/strategies/dropbox_oauth2.rb
@@ -28,11 +28,15 @@ module OmniAuth
         @raw_info ||= MultiJson.decode(access_token.get('/1/account/info').body)
       end
 
+      def callback_url_without_query_string
+        full_host + script_name + callback_path
+      end
+
       def callback_url
         if @authorization_code_from_signed_request
           ''
         else
-          options[:callback_url] || super
+          options[:callback_url] || callback_url_without_query_string
         end
       end
     end

--- a/lib/omniauth/strategies/dropbox_oauth2.rb
+++ b/lib/omniauth/strategies/dropbox_oauth2.rb
@@ -28,15 +28,11 @@ module OmniAuth
         @raw_info ||= MultiJson.decode(access_token.get('/1/account/info').body)
       end
 
-      def callback_url_without_query_string
-        full_host + script_name + callback_path
-      end
-
       def callback_url
         if @authorization_code_from_signed_request
           ''
         else
-          options[:callback_url] || callback_url_without_query_string
+          options[:callback_url] || super
         end
       end
     end

--- a/omniauth-dropbox-oauth2.gemspec
+++ b/omniauth-dropbox-oauth2.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.description = 'Dropbox OAuth2 strategy for OmniAuth 1.x'
   gem.summary     = gem.description
 
-  gem.add_dependency "omniauth-oauth2"
+  gem.add_dependency "omniauth-oauth2", "~> 1.3.1"
 
   gem.add_development_dependency 'rake'
 


### PR DESCRIPTION
request with query string parameters in the uri.

Any thoughts on this? 

Get an Oauth2::Error while fetching the access tokens from Dropbox because #callback_url call in https://github.com/intridea/omniauth/blob/master/lib/omniauth/strategy.rb#L432 seems to return URL with query string included, Dropbox says invalid grant/redirect_uri about that.

If I replace #callback_url call with new method #callback_url_without_query_string, it seems to work correctly.