### PR TITLE
change callback example url to use underscore instead of dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ end
 
 You need to add your key and secret.
 
-Also remember to add the full callback path to your Dropbox App Console, for example: https://example.com/auth/dropbox-oauth2/callback
+Also remember to add the full callback path to your Dropbox App Console, for example: https://example.com/auth/dropbox_oauth2/callback
 
 For more information check the [OmniAuth wiki](https://github.com/intridea/omniauth/wiki).
 


### PR DESCRIPTION
I was trying to set it up, but kept getting errors when trying to connect to dropbox. Couldn't figure out why it wasn't working for about a day ---- then after changing a dash in the callback url to underscore, it finally worked! 