### PR TITLE
Change uid to account_id due to shutdown of API v1

### DIFF
--- a/lib/omniauth/strategies/dropbox_oauth2.rb
+++ b/lib/omniauth/strategies/dropbox_oauth2.rb
@@ -3,14 +3,14 @@ require 'omniauth-oauth2'
 module OmniAuth
   module Strategies
     class DropboxOauth2 < OmniAuth::Strategies::OAuth2
-      option :name, "dropbox_oauth2"
+      option :name, 'dropbox_oauth2'
       option :client_options, {
         :site               => 'https://api.dropbox.com',
         :authorize_url      => 'https://www.dropbox.com/oauth2/authorize',
         :token_url          => 'https://api.dropbox.com/oauth2/token'
       }
 
-      uid { raw_info['uid'] }
+      uid { raw_info['account_id'] }
 
       info do
         {
@@ -34,10 +34,9 @@ module OmniAuth
           req.url '/2/users/get_current_account'
           req.headers['Content-Type'] = 'application/json'
           req.headers['Authorization'] = "Bearer #{access_token.token}"
-          req.body = "null"
+          req.body = 'null'
         end
         @raw_info ||= MultiJson.decode(response.body)
-        # @raw_info ||= MultiJson.decode(access_token.get('/2/users/get_current_account').body)
       end
 
       def callback_url


### PR DESCRIPTION
Hello. Dropbox API v1 [was shutdown](https://blogs.dropbox.com/developers/2017/09/api-v1-shutdown-details/) on September 28th, 2017. Here is a note from [the migration guide](https://www.dropbox.com/developers/reference/migration-guide):
> In v1, user accounts included a uid field, an integer that represented a user's Dropbox ID. In v2, we use account_id, which is a string that represents the user's unique Dropbox ID.

In this pull request `uid` was replaced with `account_id` to update the gem for API v2. Also double quotes without interpolation were replaced with single quotes.